### PR TITLE
fix(cloudmux): add modelarts created failed

### DIFF
--- a/pkg/multicloud/hcso/hcso.go
+++ b/pkg/multicloud/hcso/hcso.go
@@ -158,6 +158,14 @@ func (self *SHuaweiClient) modelartsPoolById(poolName string) (jsonutils.JSONObj
 	return self.request(httputils.GET, uri, url.Values{}, nil)
 }
 
+func (cli *SHuaweiClient) modelartsPoolListWithStatus(resource, status string, params map[string]interface{}) (jsonutils.JSONObject, error) {
+	endpoint := cli.resetEndpoint(cli.endpoints.Modelarts, "modelarts")
+	uri := fmt.Sprintf("https://%s/v2/%s/pools", endpoint, cli.projectId)
+	value := url.Values{}
+	value.Add("status", status)
+	return cli.request(httputils.GET, uri, value, params)
+}
+
 func (self *SHuaweiClient) modelartsPoolList(params map[string]interface{}) (jsonutils.JSONObject, error) {
 	endpoint := self.resetEndpoint(self.endpoints.Modelarts, "modelarts")
 	uri := fmt.Sprintf("https://%s/v2/%s/pools", endpoint, self.projectId)

--- a/pkg/multicloud/huawei/huawei.go
+++ b/pkg/multicloud/huawei/huawei.go
@@ -251,6 +251,13 @@ func (self *SHuaweiClient) modelartsPoolList(resource string, params map[string]
 	return self.request(httputils.GET, uri, url.Values{}, params)
 }
 
+func (cli *SHuaweiClient) modelartsPoolListWithStatus(resource, status string, params map[string]interface{}) (jsonutils.JSONObject, error) {
+	uri := fmt.Sprintf("https://modelarts.%s.myhuaweicloud.com/v2/%s/%s", cli.clientRegion, cli.projectId, resource)
+	value := url.Values{}
+	value.Add("status", status)
+	return cli.request(httputils.GET, uri, value, params)
+}
+
 func (self *SHuaweiClient) modelartsPoolCreate(resource string, params map[string]interface{}) (jsonutils.JSONObject, error) {
 	uri := fmt.Sprintf("https://modelarts.%s.myhuaweicloud.com/v2/%s/%s", self.clientRegion, self.projectId, resource)
 	return self.request(httputils.POST, uri, url.Values{}, params)

--- a/pkg/multicloud/huawei/modelarts_pool.go
+++ b/pkg/multicloud/huawei/modelarts_pool.go
@@ -258,7 +258,8 @@ func (self *SHuaweiClient) CreatePoolNetworks() (jsonutils.JSONObject, error) {
 			},
 		},
 		"spec": map[string]interface{}{
-			"cidr": "192.168.20.0/24",
+			// "cidr": "192.168.20.0/24",
+			"cidr": "192.168.128.0/17",
 		},
 	}
 	return self.modelartsPoolNetworkCreate(params)
@@ -343,6 +344,20 @@ func (self *SModelartsPool) SetAutoRenew(bc billing.SBillingCycle) error {
 }
 
 func (self *SModelartsPool) Refresh() error {
+	pools := make([]SModelartsPool, 0)
+	resObj, err := self.region.client.modelartsPoolListWithStatus("pools", "failed", nil)
+	if err != nil {
+		return errors.Wrap(err, "modelartsPoolListWithStatus")
+	}
+	err = resObj.Unmarshal(&pools, "items")
+	if err != nil {
+		return errors.Wrap(err, "resObj unmarshal")
+	}
+	for _, pool := range pools {
+		if pool.GetId() == self.GetId() {
+			self.Status.Phase = "CreationFailed"
+		}
+	}
 	self.Status.Resource = SNodeStatus{}
 	pool, err := self.region.client.modelartsPoolById(self.GetId())
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix modelarts refresh :add modelarts created failed

**Does this PR need to be backport to the previous release branch?**:

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.10

/cc @ioito 
