### PR TITLE
Automated cherry pick of #134: fix(common): default host cpu arch is x86_64

### DIFF
--- a/pkg/multicloud/host_base.go
+++ b/pkg/multicloud/host_base.go
@@ -14,6 +14,8 @@
 
 package multicloud
 
+import "yunion.io/x/cloudmux/pkg/apis"
+
 type SHostBase struct {
 	SResourceBase
 	STagBase
@@ -40,5 +42,5 @@ func (host *SHostBase) GetOvnVersion() string {
 }
 
 func (host *SHostBase) GetCpuArchitecture() string {
-	return ""
+	return apis.OS_ARCH_X86_64
 }


### PR DESCRIPTION
Cherry pick of #134 on release/3.10.

#134: fix(common): default host cpu arch is x86_64