### PR TITLE
Automated cherry pick of #139: fix(qcloud): skip unsupport memcache

### DIFF
--- a/pkg/multicloud/qcloud/region.go
+++ b/pkg/multicloud/qcloud/region.go
@@ -860,6 +860,9 @@ func (region *SRegion) GetIElasticcaches() ([]cloudprovider.ICloudElasticcache, 
 	for {
 		part, total, err := region.GetMemcaches(nil, 100, offset)
 		if err != nil {
+			if errors.Cause(err) == cloudprovider.ErrNotSupported {
+				return ret, nil
+			}
 			return nil, errors.Wrapf(err, "GetMemcaches")
 		}
 		mems = append(mems, part...)

--- a/pkg/multicloud/qcloud/shell/elasticcache.go
+++ b/pkg/multicloud/qcloud/shell/elasticcache.go
@@ -32,6 +32,21 @@ func init() {
 		return nil
 	})
 
+	type MemcacheListOptions struct {
+		Ids    []string
+		Limit  int
+		Offset int
+	}
+
+	shellutils.R(&MemcacheListOptions{}, "memcache-list", "List memcaches", func(cli *qcloud.SRegion, args *MemcacheListOptions) error {
+		redis, _, err := cli.GetMemcaches(args.Ids, args.Limit, args.Offset)
+		if err != nil {
+			return err
+		}
+		printList(redis, 0, 0, 0, []string{})
+		return nil
+	})
+
 	type RedisParameterListOptions struct {
 		INSTANCEID string `json:"instanceid"`
 	}


### PR DESCRIPTION
Cherry pick of #139 on release/3.10.

#139: fix(qcloud): skip unsupport memcache