### PR TITLE
Automated cherry pick of #181: fix(google): gcp storage cache

### DIFF
--- a/pkg/multicloud/google/storagecache.go
+++ b/pkg/multicloud/google/storagecache.go
@@ -39,7 +39,7 @@ type SStoragecache struct {
 }
 
 func (cache *SStoragecache) GetId() string {
-	return cache.region.client.cpcfg.Id
+	return fmt.Sprintf("%s-%s", cache.region.client.cpcfg.Id, cache.region.GetGlobalId())
 }
 
 func (cache *SStoragecache) GetName() string {


### PR DESCRIPTION
Cherry pick of #181 on release/3.10.

#181: fix(google): gcp storage cache