### PR TITLE
Automated cherry pick of #183: fix(google): gcp storage cache

### DIFF
--- a/pkg/multicloud/google/storagecache.go
+++ b/pkg/multicloud/google/storagecache.go
@@ -55,7 +55,7 @@ func (cache *SStoragecache) Refresh() error {
 }
 
 func (cache *SStoragecache) GetGlobalId() string {
-	return cache.region.client.cpcfg.Id
+	return cache.GetId()
 }
 
 func (cache *SStoragecache) IsEmulated() bool {


### PR DESCRIPTION
Cherry pick of #183 on release/3.10.

#183: fix(google): gcp storage cache