### PR TITLE
Automated cherry pick of #197: fix(openstack): compute api version

### DIFF
--- a/pkg/multicloud/openstack/openstack.go
+++ b/pkg/multicloud/openstack/openstack.go
@@ -27,7 +27,6 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/httputils"
 	"yunion.io/x/pkg/util/version"
-	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/cloudmux/pkg/apis/compute"
 	"yunion.io/x/cloudmux/pkg/cloudprovider"
@@ -251,7 +250,11 @@ func (cli *SOpenStackClient) jsonReuest(token oscli.TokenCredential, service, re
 	header := http.Header{}
 	header.Set("X-Auth-Token", token.GetTokenString())
 	apiVersion := ""
-	if !utils.IsInStringArray(service, []string{OPENSTACK_SERVICE_IMAGE, OPENSTACK_SERVICE_IDENTITY}) {
+	switch service {
+	case OPENSTACK_SERVICE_IMAGE, OPENSTACK_SERVICE_IDENTITY:
+	case OPENSTACK_SERVICE_COMPUTE:
+		apiVersion = "2.1"
+	default:
 		apiVersion, err = cli.getApiVerion(token, serviceUrl, debug)
 		if err != nil {
 			log.Errorf("get service %s api version error: %v", service, err)


### PR DESCRIPTION
Cherry pick of #197 on release/3.10.

#197: fix(openstack): compute api version