### PR TITLE
fix: vmware wire id should be scoped by cloud account

### DIFF
--- a/pkg/multicloud/esxi/wire.go
+++ b/pkg/multicloud/esxi/wire.go
@@ -42,7 +42,11 @@ func (wire *sWire) GetName() string {
 }
 
 func (wire *sWire) GetGlobalId() string {
-	return wire.network.GetId()
+	if wire.client.IsVCenter() {
+		return fmt.Sprintf("%s/%s", wire.client.GetUUID(), wire.network.GetId())
+	} else {
+		return wire.network.GetId()
+	}
 }
 
 func (wire *sWire) GetCreatedAt() time.Time {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: vmware wire id should be scoped by cloud account

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.10

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito @zexi 