### PR TITLE
fix: more details when esxi get_network_by_id error

### DIFF
--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -163,11 +163,11 @@ func NewVNICDev(host *SHost, mac, driver string, bridge string, vlanId int32, ke
 
 	inet, err := host.getNetworkById(bridge)
 	if err != nil {
-		return nil, errors.Wrap(err, "GetNetworkById")
+		return nil, errors.Wrapf(err, "GetNetworkById %s on host %s", bridge, host.GetName())
 	}
 
 	if inet == nil {
-		return nil, errors.Error(fmt.Sprintf("Bridge %s VLAN %d not found", bridge, vlanId))
+		return nil, errors.Wrapf(errors.ErrNotFound, "Bridge %s not found on host %s", bridge, host.GetName())
 	}
 
 	var backing types.BaseVirtualDeviceBackingInfo


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: more details when esxi get_network_by_id error

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.10

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito @zexi 