### PR TITLE
Automated cherry pick of #517: fix(region): aws default secgroup delete

### DIFF
--- a/pkg/multicloud/aws/securitygroup.go
+++ b/pkg/multicloud/aws/securitygroup.go
@@ -245,6 +245,9 @@ func (self *SRegion) GetSecurityGroups(vpcId string, name string, secgroupId str
 }
 
 func (self *SSecurityGroup) Delete() error {
+	if self.GroupName == "default" {
+		return cloudprovider.ErrNotSupported
+	}
 	return self.region.DeleteSecurityGroup(self.GroupId)
 }
 


### PR DESCRIPTION
Cherry pick of #517 on release/3.11.

#517: fix(region): aws default secgroup delete