### PR TITLE
Automated cherry pick of #545: fix(pve): min vm id

### DIFF
--- a/pkg/multicloud/proxmox/cluster.go
+++ b/pkg/multicloud/proxmox/cluster.go
@@ -152,7 +152,7 @@ func (self *SRegion) GetClusterVmMaxId() int {
 	}
 
 	if len(idxs) < 1 {
-		return 0
+		return 99
 	}
 
 	sort.Ints(idxs)


### PR DESCRIPTION
Cherry pick of #545 on release/3.11.

#545: fix(pve): min vm id