### PR TITLE
fix(region): move sslcert from Region to CloudProvider

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -319,6 +319,8 @@ type ICloudProvider interface {
 	CreateICloudCDNDomain(opts *CdnCreateOptions) (ICloudCDNDomain, error)
 
 	GetMetrics(opts *MetricListOptions) ([]MetricValues, error)
+
+	GetISSLCertificates() ([]ICloudSSLCertificate, error)
 }
 
 func IsSupportCapability(prod ICloudProvider, capa string) bool {
@@ -642,6 +644,10 @@ func (self *SBaseProvider) CreateIModelartsPool(pool *ModelartsPoolCreateOption,
 
 func (self *SBaseProvider) GetIModelartsPoolSku() ([]ICloudModelartsPoolSku, error) {
 	return nil, errors.Wrapf(ErrNotImplemented, "GetIModelartsPoolSku")
+}
+
+func (self *SBaseProvider) GetISSLCertificates() ([]ICloudSSLCertificate, error) {
+	return nil, errors.Wrapf(ErrNotImplemented, "GetISSLCertificates")
 }
 
 func NewBaseProvider(factory ICloudProviderFactory) SBaseProvider {

--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -203,8 +203,6 @@ type ICloudRegion interface {
 	GetIModelartsPoolSku() ([]ICloudModelartsPoolSku, error)
 
 	GetIMiscResources() ([]ICloudMiscResource, error)
-
-	GetISSLCertificates() ([]ICloudSSLCertificate, error)
 }
 
 type ICloudZone interface {

--- a/pkg/multicloud/aliyun/provider/provider.go
+++ b/pkg/multicloud/aliyun/provider/provider.go
@@ -527,3 +527,11 @@ func (self *SAliyunProvider) GetICloudCDNDomainByName(name string) (cloudprovide
 func (self *SAliyunProvider) GetMetrics(opts *cloudprovider.MetricListOptions) ([]cloudprovider.MetricValues, error) {
 	return self.client.GetMetrics(opts)
 }
+
+func (self *SAliyunProvider) GetISSLCertificates() ([]cloudprovider.ICloudSSLCertificate, error) {
+	return self.client.GetISSLCertificates()
+}
+
+func (self *SAliyunProvider) GetISSLCertificate(certId string) (cloudprovider.ICloudSSLCertificate, error) {
+	return self.client.GetISSLCertificate(certId)
+}

--- a/pkg/multicloud/aliyun/shell/sslcertificate.go
+++ b/pkg/multicloud/aliyun/shell/sslcertificate.go
@@ -16,7 +16,7 @@ func init() {
 		"sslcertificate-list",
 		"List ssl certificates",
 		func(cli *aliyun.SRegion, args *SSlCertificateListOptions) error {
-			certs, _, err := cli.GetSSLCertificates(args.Size, args.Page)
+			certs, _, err := cli.GetClient().GetSSLCertificates(args.Size, args.Page)
 			if err != nil {
 				return err
 			}

--- a/pkg/multicloud/huawei/huawei.go
+++ b/pkg/multicloud/huawei/huawei.go
@@ -57,8 +57,9 @@ const (
 	HUAWEI_INTERNATIONAL_CLOUDENV = "InternationalCloud"
 	HUAWEI_CHINA_CLOUDENV         = "ChinaCloud"
 
-	HUAWEI_DEFAULT_REGION = "cn-north-1"
-	HUAWEI_API_VERSION    = "2018-12-25"
+	HUAWEI_DEFAULT_REGION      = "cn-north-1"
+	HUAWEI_CERT_DEFAULT_REGION = "cn-north-4"
+	HUAWEI_API_VERSION         = "2018-12-25"
 
 	SERVICE_IAM       = "iam"
 	SERVICE_ELB       = "elb"
@@ -126,8 +127,9 @@ type SHuaweiClient struct {
 
 	signer auth.Signer
 
-	isMainProject bool // whether the project is the main project in the region
-	clientRegion  string
+	isMainProject     bool // whether the project is the main project in the region
+	isSyncCertProject bool
+	clientRegion      string
 
 	userId          string
 	ownerId         string
@@ -483,6 +485,9 @@ func (self *SHuaweiClient) fetchRegions() error {
 				self.isMainProject = true
 			}
 		}
+		if project.Name == HUAWEI_CERT_DEFAULT_REGION {
+			self.isSyncCertProject = true
+		}
 	} else {
 		filtedRegions = self.regions
 	}
@@ -796,6 +801,41 @@ func (self *SHuaweiClient) queryDomainBalances(domainId string) ([]SBalance, err
 	return balances, nil
 }
 
+func (self *SHuaweiClient) GetISSLCertificates() ([]cloudprovider.ICloudSSLCertificate, error) {
+	ret := make([]SSSLCertificate, 0)
+	offset := 0
+
+	for {
+		part, total, err := self.GetSSLCertificates(50, offset)
+		if err != nil {
+			return nil, errors.Wrapf(err, "GetSSLCertificates")
+		}
+
+		ret = append(ret, part...)
+		if len(ret) >= total {
+			break
+		}
+
+		offset += 50
+	}
+
+	result := make([]cloudprovider.ICloudSSLCertificate, 0)
+	for i := range ret {
+		ret[i].client = self
+		result = append(result, &ret[i])
+	}
+	return result, nil
+}
+
+func (self *SHuaweiClient) GetISSLCertificate(certId string) (cloudprovider.ICloudSSLCertificate, error) {
+	var res cloudprovider.ICloudSSLCertificate
+	res, err := self.GetSSLCertificate(certId)
+	if err != nil {
+		return nil, errors.Wrapf(err, "GetSSLCertificate")
+	}
+	return res, nil
+}
+
 func (self *SHuaweiClient) GetVersion() string {
 	return HUAWEI_API_VERSION
 }
@@ -830,13 +870,15 @@ func (self *SHuaweiClient) GetCapabilities() []string {
 		cloudprovider.CLOUD_CAPABILITY_QUOTA + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_MODELARTES,
 		cloudprovider.CLOUD_CAPABILITY_VPC_PEER,
-		cloudprovider.CLOUD_CAPABILITY_CERT,
 	}
 	// huawei objectstore is shared across projects(subscriptions)
 	// to avoid multiple project access the same bucket
 	// only main project is allow to access objectstore bucket
 	if self.isMainProject {
 		caps = append(caps, cloudprovider.CLOUD_CAPABILITY_OBJECTSTORE)
+	}
+	if self.isSyncCertProject {
+		caps = append(caps, cloudprovider.CLOUD_CAPABILITY_CERT)
 	}
 	return caps
 }

--- a/pkg/multicloud/huawei/provider/provider.go
+++ b/pkg/multicloud/huawei/provider/provider.go
@@ -311,3 +311,11 @@ func (self *SHuaweiProvider) GetMetrics(opts *cloudprovider.MetricListOptions) (
 	}
 	return metrics, nil
 }
+
+func (self *SHuaweiProvider) GetISSLCertificates() ([]cloudprovider.ICloudSSLCertificate, error) {
+	return self.client.GetISSLCertificates()
+}
+
+func (self *SHuaweiProvider) GetISSLCertificate(certId string) (cloudprovider.ICloudSSLCertificate, error) {
+	return self.client.GetISSLCertificate(certId)
+}

--- a/pkg/multicloud/huawei/shell/sslcertificate.go
+++ b/pkg/multicloud/huawei/shell/sslcertificate.go
@@ -15,7 +15,7 @@ func init() {
 		"sslcertificate-list",
 		"List ssl certificates",
 		func(cli *huawei.SRegion, args *SSlCertificateListOptions) error {
-			certs, _, err := cli.GetSSLCertificates(args.Size, args.Page)
+			certs, _, err := cli.GetClient().GetSSLCertificates(args.Size, args.Page)
 			if err != nil {
 				return err
 			}

--- a/pkg/multicloud/qcloud/provider/provider.go
+++ b/pkg/multicloud/qcloud/provider/provider.go
@@ -466,3 +466,7 @@ func (self *SQcloudProvider) CreateICloudCDNDomain(opts *cloudprovider.CdnCreate
 func (self *SQcloudProvider) GetMetrics(opts *cloudprovider.MetricListOptions) ([]cloudprovider.MetricValues, error) {
 	return self.client.GetMetrics(opts)
 }
+
+func (self *SQcloudProvider) GetISSLCertificates() ([]cloudprovider.ICloudSSLCertificate, error) {
+	return self.client.GetISSLCertificates()
+}

--- a/pkg/multicloud/qcloud/qcloud.go
+++ b/pkg/multicloud/qcloud/qcloud.go
@@ -982,6 +982,20 @@ func (client *SQcloudClient) GetIProjects() ([]cloudprovider.ICloudProject, erro
 	return iprojects, nil
 }
 
+func (self *SQcloudClient) GetISSLCertificates() ([]cloudprovider.ICloudSSLCertificate, error) {
+	rs, err := self.GetCertificates("", "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]cloudprovider.ICloudSSLCertificate, 0)
+	for i := range rs {
+		rs[i].client = self
+		result = append(result, &rs[i])
+	}
+	return result, nil
+}
+
 func (self *SQcloudClient) GetCapabilities() []string {
 	caps := []string{
 		cloudprovider.CLOUD_CAPABILITY_PROJECT,


### PR DESCRIPTION
**What this PR does / why we need it**:

证书资源方法从SRegion下改为SProvider和Client下

由于华为较特殊 一个云账号对应多个provider, huawei client 增加字段isSyncCertProject来区分出同步的那个provider