### PR TITLE
Automated cherry pick of #632: fix: set subaccount id for non-public clouds

### DIFF
--- a/pkg/multicloud/bingocloud/bingo.go
+++ b/pkg/multicloud/bingocloud/bingo.go
@@ -299,6 +299,7 @@ func (self *SBingoCloudClient) GetSubAccounts() ([]cloudprovider.SSubAccount, er
 	var subAccounts []cloudprovider.SSubAccount
 	for i := range tags {
 		subAccount := cloudprovider.SSubAccount{
+			Id:               tags[i].ResourceId,
 			Account:          self.accessKey,
 			Name:             tags[i].ResourceId,
 			DefaultProjectId: tags[i].Value,

--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -310,6 +310,7 @@ func (cli *SESXiClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 		return nil, err
 	}
 	subAccount := cloudprovider.SSubAccount{
+		Id:           cli.GetGlobalId(),
 		Account:      cli.account,
 		Name:         cli.cpcfg.Name,
 		HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,

--- a/pkg/multicloud/hcso/huawei.go
+++ b/pkg/multicloud/hcso/huawei.go
@@ -371,6 +371,7 @@ func (self *SHuaweiClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error)
 		}
 
 		s := cloudprovider.SSubAccount{
+			Id:           project.ID,
 			Name:         fmt.Sprintf("%s-%s", self.cpcfg.Name, project.Name),
 			Account:      fmt.Sprintf("%s/%s", self.accessKey, project.ID),
 			HealthStatus: project.GetHealthStatus(),

--- a/pkg/multicloud/nutanix/nutanix.go
+++ b/pkg/multicloud/nutanix/nutanix.go
@@ -330,6 +330,7 @@ func (self *SNutanixClient) get(res string, id string, params url.Values, retVal
 
 func (self *SNutanixClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 	subAccount := cloudprovider.SSubAccount{
+		Id:           self.GetAccountId(),
 		Account:      self.username,
 		Name:         self.cpcfg.Name,
 		HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,

--- a/pkg/multicloud/objectstore/objectstore.go
+++ b/pkg/multicloud/objectstore/objectstore.go
@@ -147,6 +147,7 @@ func NewObjectStoreClientAndFetch(cfg *ObjectStoreClientConfig, doFetch bool) (*
 
 func (cli *SObjectStoreClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 	subAccount := cloudprovider.SSubAccount{
+		Id:           cli.GetAccountId(),
 		Account:      cli.accessKey,
 		Name:         cli.cpcfg.Name,
 		HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,

--- a/pkg/multicloud/objectstore/xsky/xsky.go
+++ b/pkg/multicloud/objectstore/xsky/xsky.go
@@ -110,6 +110,7 @@ func (cli *SXskyClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 	if len(cli.initAccount) > 0 {
 		return []cloudprovider.SSubAccount{
 			{
+				Id:           fmt.Sprintf("%d", cli.adminUser.Id),
 				Account:      cli.initAccount,
 				Name:         cli.adminUser.Name,
 				HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,
@@ -125,6 +126,7 @@ func (cli *SXskyClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 		ak := usrs[i].getMinKey()
 		if len(ak) > 0 {
 			subAccount := cloudprovider.SSubAccount{
+				Id:           fmt.Sprintf("%d", usrs[i].Id),
 				Account:      fmt.Sprintf("%s/%s", cli.adminApi.username, ak),
 				Name:         usrs[i].Name,
 				HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,

--- a/pkg/multicloud/openstack/openstack.go
+++ b/pkg/multicloud/openstack/openstack.go
@@ -145,6 +145,7 @@ func (cli *SOpenStackClient) GetSubAccounts() ([]cloudprovider.SSubAccount, erro
 	subAccount := cloudprovider.SSubAccount{
 		Account: fmt.Sprintf("%s/%s", cli.project, cli.username),
 		Name:    cli.cpcfg.Name,
+		Id:      cli.tokenCredential.GetProjectDomainId(),
 
 		HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,
 	}

--- a/pkg/multicloud/proxmox/proxmox.go
+++ b/pkg/multicloud/proxmox/proxmox.go
@@ -370,6 +370,7 @@ func (cli *SProxmoxClient) upload(node, storageName, filename string, reader io.
 
 func (self *SProxmoxClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 	subAccount := cloudprovider.SSubAccount{}
+	subAccount.Id = self.host
 	subAccount.Name = self.cpcfg.Name
 	subAccount.Account = self.username
 	subAccount.HealthStatus = api.CLOUD_PROVIDER_HEALTH_NORMAL

--- a/pkg/multicloud/remotefile/remotefile.go
+++ b/pkg/multicloud/remotefile/remotefile.go
@@ -105,6 +105,7 @@ func (cli *SRemoteFileClient) GetSubAccounts() ([]cloudprovider.SSubAccount, err
 	subAccount := cloudprovider.SSubAccount{
 		Account: cli.cpcfg.Id,
 		Name:    cli.cpcfg.Name,
+		Id:      cli.cpcfg.Id,
 
 		HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,
 	}

--- a/pkg/multicloud/zstack/zstack.go
+++ b/pkg/multicloud/zstack/zstack.go
@@ -136,6 +136,7 @@ func (cli *SZStackClient) GetCloudRegionExternalIdPrefix() string {
 
 func (cli *SZStackClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 	subAccount := cloudprovider.SSubAccount{
+		Id:           cli.cpcfg.Id,
 		Account:      cli.username,
 		Name:         cli.cpcfg.Name,
 		HealthStatus: api.CLOUD_PROVIDER_HEALTH_NORMAL,


### PR DESCRIPTION
Cherry pick of #632 on release/3.11.

#632: fix: set subaccount id for non-public clouds