### PR TITLE
Automated cherry pick of #673: fix(huawei): skip sync huawei ipv6 eip

### DIFF
--- a/pkg/multicloud/huawei/eip.go
+++ b/pkg/multicloud/huawei/eip.go
@@ -330,6 +330,7 @@ func (self *SRegion) GetEips(portId string, addrs []string) ([]SEipAddress, erro
 	if len(portId) > 0 {
 		query.Set("port_id", portId)
 	}
+	query.Set("ip_version", "4")
 	eips := []SEipAddress{}
 	for {
 		resp, err := self.list(SERVICE_VPC_V3, "eip/publicips", query)

--- a/pkg/multicloud/huawei/instance.go
+++ b/pkg/multicloud/huawei/instance.go
@@ -407,7 +407,7 @@ func (self *SInstance) GetIEIP() (cloudprovider.ICloudEIP, error) {
 	ips := make([]string, 0)
 	for _, addresses := range self.Addresses {
 		for _, address := range addresses {
-			if address.OSEXTIPSType != "fixed" && !strings.HasPrefix(address.Addr, "100.") {
+			if address.OSEXTIPSType != "fixed" && !strings.HasPrefix(address.Addr, "100.") && address.Version == "4" {
 				ips = append(ips, address.Addr)
 			}
 		}


### PR DESCRIPTION
Cherry pick of #673 on release/3.11.

#673: fix(huawei): skip sync huawei ipv6 eip