### PR TITLE
Automated cherry pick of #688: fix(huawei): skip hw networkinterface sync

### DIFF
--- a/pkg/multicloud/huawei/port.go
+++ b/pkg/multicloud/huawei/port.go
@@ -17,8 +17,6 @@ package huawei
 import (
 	"strings"
 
-	"yunion.io/x/pkg/utils"
-
 	api "yunion.io/x/cloudmux/pkg/apis/compute"
 	"yunion.io/x/cloudmux/pkg/cloudprovider"
 	"yunion.io/x/cloudmux/pkg/multicloud"
@@ -127,19 +125,9 @@ func (port *Port) GetICloudInterfaceAddresses() ([]cloudprovider.ICloudInterface
 	return address, nil
 }
 
+// 华为云端口API device_owner 变化会导致子网ip重复同步，故忽略弹性网卡同步
 func (region *SRegion) GetINetworkInterfaces() ([]cloudprovider.ICloudNetworkInterface, error) {
-	ports, err := region.GetPorts("")
-	if err != nil {
-		return nil, err
-	}
-	ret := []cloudprovider.ICloudNetworkInterface{}
-	for i := 0; i < len(ports); i++ {
-		if len(ports[i].DeviceID) == 0 || !utils.IsInStringArray(ports[i].DeviceOwner, []string{"compute:CCI", "compute:nova", "neutron:LOADBALANCERV2"}) {
-			ports[i].region = region
-			ret = append(ret, &ports[i])
-		}
-	}
-	return ret, nil
+	return []cloudprovider.ICloudNetworkInterface{}, nil
 }
 
 func (self *SRegion) GetPort(portId string) (Port, error) {


### PR DESCRIPTION
Cherry pick of #688 on release/3.10.

#688: fix(huawei): skip hw networkinterface sync