### PR TITLE
Automated cherry pick of #715: fix(qcloud): avoid unmarshal lb backend tags error

### DIFF
--- a/pkg/multicloud/qcloud/loadbalancer_backend.go
+++ b/pkg/multicloud/qcloud/loadbalancer_backend.go
@@ -27,7 +27,7 @@ import (
 
 type SLBBackend struct {
 	multicloud.SResourceBase
-	QcloudTags
+	multicloud.STagBase
 	group *SLBBackendGroup
 
 	PublicIPAddresses  []string `json:"PublicIpAddresses"`


### PR DESCRIPTION
Cherry pick of #715 on release/3.11.

#715: fix(qcloud): avoid unmarshal lb backend tags error