### PR TITLE
Automated cherry pick of #739: fix(esxi): migrate vm choices usable datastore

### DIFF
--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -104,6 +104,11 @@ func (self *SDatastore) GetCapacityUsedMB() int64 {
 	return self.GetCapacityMB() - moStore.Summary.FreeSpace/1024/1024
 }
 
+func (self *SDatastore) GetCapacityFreeMB() int64 {
+	moStore := self.getDatastore()
+	return moStore.Summary.FreeSpace / 1024 / 1024
+}
+
 func (self *SDatastore) GetEnabled() bool {
 	return true
 }

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -1601,7 +1601,18 @@ func (self *SVirtualMachine) relocate(hostId string) error {
 		}
 	}
 	if !isShared {
-		config.Datastore = &targetHs.Datastore[0]
+		err := host.fetchDatastores()
+		if err != nil {
+			return errors.Wrapf(err, "fetchDatastores")
+		}
+		max := int64(0)
+		for i := range host.datastores {
+			ds := host.datastores[i].(*SDatastore)
+			if ds.GetCapacityFreeMB() > max {
+				max = ds.GetCapacityFreeMB()
+				config.Datastore = &targetHs.Datastore[i]
+			}
+		}
 	}
 	task, err := self.getVmObj().Relocate(ctx, config, types.VirtualMachineMovePriorityDefaultPriority)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #739 on release/3.10.

#739: fix(esxi): migrate vm choices usable datastore