### PR TITLE
Automated cherry pick of #811: fix(huawei): ignore invalid nat sync

### DIFF
--- a/pkg/multicloud/huawei/vpc.go
+++ b/pkg/multicloud/huawei/vpc.go
@@ -127,7 +127,7 @@ func (self *SVpc) GetIWireById(wireId string) (cloudprovider.ICloudWire, error) 
 
 func (self *SVpc) GetINatGateways() ([]cloudprovider.ICloudNatGateway, error) {
 	nats, err := self.region.GetNatGateways(self.GetId(), "")
-	if err != nil {
+	if err != nil && errors.Cause(err) != cloudprovider.ErrNotFound {
 		return nil, err
 	}
 	nats2, err := self.region.GetNatgateways(self.GetId(), "")


### PR DESCRIPTION
Cherry pick of #811 on release/3.11.

#811: fix(huawei): ignore invalid nat sync