### PR TITLE
Automated cherry pick of #811: fix(huawei): ignore invalid nat sync

### DIFF
--- a/pkg/multicloud/huawei/vpc.go
+++ b/pkg/multicloud/huawei/vpc.go
@@ -207,7 +207,7 @@ func (self *SVpc) GetIWireById(wireId string) (cloudprovider.ICloudWire, error) 
 
 func (self *SVpc) GetINatGateways() ([]cloudprovider.ICloudNatGateway, error) {
 	nats, err := self.region.GetNatGateways(self.GetId(), "")
-	if err != nil {
+	if err != nil && errors.Cause(err) != cloudprovider.ErrNotFound {
 		return nil, err
 	}
 	ret := make([]cloudprovider.ICloudNatGateway, len(nats))


### PR DESCRIPTION
Cherry pick of #811 on release/3.10.

#811: fix(huawei): ignore invalid nat sync