### PR TITLE
Automated cherry pick of #857: fix(aws): aws instance image info

### DIFF
--- a/pkg/multicloud/aws/image.go
+++ b/pkg/multicloud/aws/image.go
@@ -247,7 +247,7 @@ func (self *SImage) GetSizeByte() int64 {
 
 func (self *SImage) getNormalizedImageInfo() *imagetools.ImageInfo {
 	if self.imgInfo == nil {
-		imgInfo := imagetools.NormalizeImageInfo("", self.Architecture, getImageOSType(*self), getImageOSDist(*self), getImageOSVersion(*self))
+		imgInfo := imagetools.NormalizeImageInfo(self.ImageName, self.Architecture, getImageOSType(*self), getImageOSDist(*self), getImageOSVersion(*self))
 		self.imgInfo = &imgInfo
 	}
 	return self.imgInfo


### PR DESCRIPTION
Cherry pick of #857 on release/3.11.

#857: fix(aws): aws instance image info