### PR TITLE
Automated cherry pick of #889: fix(qcloud): vpc not found

### DIFF
--- a/pkg/multicloud/qcloud/region.go
+++ b/pkg/multicloud/qcloud/region.go
@@ -366,7 +366,7 @@ func (self *SRegion) GetVpc(vpcId string) (*SVpc, error) {
 			return &vpcs[i], nil
 		}
 	}
-	return nil, errors.Wrapf(err, "GetVpc(%s)", vpcId)
+	return nil, errors.Wrapf(cloudprovider.ErrNotFound, "GetVpc(%s)", vpcId)
 }
 
 func (self *SRegion) GetVpcs(vpcIds []string) ([]SVpc, error) {


### PR DESCRIPTION
Cherry pick of #889 on release/3.11.

#889: fix(qcloud): vpc not found