### PR TITLE
fix: cloudmux lock pkg tag at release/3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,10 @@ fmt:
 GOPROXY ?= direct
 
 mod:
-	GOPROXY=$(GOPROXY) GOSUMDB=off go get -d $(patsubst %,%@master,$(shell GO111MODULE=on go mod edit -print  | sed -n -e 's|.*\(yunion.io/x/[a-z].*\) v.*|\1|p' | grep -v '/pkg$$'))
-	go mod tidy
+	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go get -d yunion.io/x/pkg@v1.10.0
+	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go get -d $(patsubst %,%@master,$(shell GO111MODULE=on go mod edit -print  | sed -n -e 's|.*\(yunion.io/x/[a-z].*\) v.*|\1|p' | grep -v '/pkg$$'))
+	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go mod tidy
+	GOPROXY=$(GOPROXY) GONOSUMDB=yunion.io/x go mod vendor -v
 
 
 REGISTRY ?= "registry.cn-beijing.aliyuncs.com/yunionio"

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	gopkg.in/fatih/set.v0 v0.2.1
 	moul.io/http2curl/v2 v2.3.0
 	yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401
-	yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361
+	yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91
 	yunion.io/x/pkg v1.10.0
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 	yunion.io/x/structarg v0.0.0-20231017124457-df4d5009457c

--- a/go.sum
+++ b/go.sum
@@ -606,8 +606,8 @@ yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH
 yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401 h1:4l6ELFSQ0MBVInscZ8/yOtSWF0cwH5BT1ATN6dCtAqc=
 yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401/go.mod h1:VK4Z93dgiKgAijcSqbMKmGaBMJuHulR16Hz4K015ZPo=
 yunion.io/x/log v0.0.0-20190514041436-04ce53b17c6b/go.mod h1:+gauLs73omeJAPlsXcevLsJLKixV+sR/E7WSYTSx1fE=
-yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361 h1:c5LyNdhbvBe/92pXs9jgXOU/S+RgYh/DHe538LpT/Mo=
-yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361/go.mod h1:LC6f/4FozL0iaAbnFt2eDX9jlsyo3WiOUPm03d7+U4U=
+yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91 h1:inY5o3LDa/zgsIZuPN0HmpzKIsu/lLgsBmMttuDPGj4=
+yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91/go.mod h1:LC6f/4FozL0iaAbnFt2eDX9jlsyo3WiOUPm03d7+U4U=
 yunion.io/x/pkg v0.0.0-20190620104149-945c25821dbf/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v1.10.0 h1:A0L/ebGyF3+z+kXGRifnpMaLX1GSOHwNx6ocLR6cKRw=
 yunion.io/x/pkg v1.10.0/go.mod h1:ksCJVQ+DwKrJ5QBEoU8pzrDFfDaZVAFH/iJ6yQCYxJk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -567,7 +567,7 @@ moul.io/http2curl/v2
 # yunion.io/x/jsonutils v1.0.1-0.20240203102553-4096f103b401
 ## explicit; go 1.18
 yunion.io/x/jsonutils
-# yunion.io/x/log v1.0.1-0.20230411060016-feb3f46ab361
+# yunion.io/x/log v1.0.1-0.20240305175729-7cf2d6cd5a91
 ## explicit; go 1.12
 yunion.io/x/log
 yunion.io/x/log/hooks

--- a/vendor/yunion.io/x/log/log.go
+++ b/vendor/yunion.io/x/log/log.go
@@ -17,6 +17,7 @@ package log
 
 import (
 	"runtime"
+	"runtime/debug"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -134,10 +135,12 @@ func Errorln(args ...interface{}) {
 }
 
 func Fatalf(format string, args ...interface{}) {
+	debug.PrintStack()
 	logrus.Fatalf(format, args...)
 }
 
 func Fatalln(args ...interface{}) {
+	debug.PrintStack()
 	logrus.Fatalln(args...)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: cloudmux lock pkg tag at release/3.10

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.10

Take a look at "https://www.cloudpods.org/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @ioito 