### PR TITLE
Automated cherry pick of #994: fix(qcloud): nat capability sync

### DIFF
--- a/pkg/multicloud/qcloud/qcloud.go
+++ b/pkg/multicloud/qcloud/qcloud.go
@@ -1053,6 +1053,7 @@ func (self *SQcloudClient) GetCapabilities() []string {
 		cloudprovider.CLOUD_CAPABILITY_CDN + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_CONTAINER + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_CERT,
+		cloudprovider.CLOUD_CAPABILITY_NAT + cloudprovider.READ_ONLY_SUFFIX,
 		cloudprovider.CLOUD_CAPABILITY_SNAPSHOT_POLICY,
 		cloudprovider.CLOUD_CAPABILITY_WAF + cloudprovider.READ_ONLY_SUFFIX,
 	}


### PR DESCRIPTION
Cherry pick of #994 on release/3.11.

#994: fix(qcloud): nat capability sync