### PR TITLE
Automated cherry pick of #1038: fix(qcloud): lb backend ip sync

### DIFF
--- a/pkg/multicloud/qcloud/loadbalancer_backend.go
+++ b/pkg/multicloud/qcloud/loadbalancer_backend.go
@@ -111,6 +111,11 @@ func (self *SLBBackend) GetBackendId() string {
 }
 
 func (self *SLBBackend) GetIpAddress() string {
+	for _, ip := range self.PrivateIPAddresses {
+		if len(ip) > 0 {
+			return ip
+		}
+	}
 	return ""
 }
 


### PR DESCRIPTION
Cherry pick of #1038 on release/3.11.6.

#1038: fix(qcloud): lb backend ip sync