### PR TITLE
Automated cherry pick of #970: fix: ceph reuse http connection (reported by GDYT)

### DIFF
--- a/pkg/multicloud/objectstore/objectstore.go
+++ b/pkg/multicloud/objectstore/objectstore.go
@@ -15,9 +15,11 @@
 package objectstore
 
 import (
+	"net"
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -126,6 +128,12 @@ func NewObjectStoreClientAndFetch(cfg *ObjectStoreClientConfig, doFetch bool) (*
 
 	tr := httputils.GetTransport(true)
 	tr.Proxy = cfg.cpcfg.ProxyFunc
+	tr.DialContext = (&net.Dialer{
+		Timeout:   60 * time.Second,
+		KeepAlive: 60 * time.Second,
+		DualStack: true,
+	}).DialContext
+	tr.IdleConnTimeout = 90 * time.Second
 	cli.SetCustomTransport(tr)
 
 	client.client = cli


### PR DESCRIPTION
Cherry pick of #970 on release/3.11.

#970: fix: ceph reuse http connection (reported by GDYT)