### PR TITLE
Automated cherry pick of #1089: fix(qcloud): lb listener health check type

### DIFF
--- a/pkg/multicloud/qcloud/loadbalancer_listener.go
+++ b/pkg/multicloud/qcloud/loadbalancer_listener.go
@@ -587,7 +587,7 @@ func healthCheck(params map[string]string, listenerType string, opts *cloudprovi
 			params["HealthCheck.IntervalTime"] = fmt.Sprintf("%d", opts.HealthCheckInterval)
 			params["HealthCheck.HealthNum"] = fmt.Sprintf("%d", opts.HealthCheckRise)
 			params["HealthCheck.UnHealthNum"] = fmt.Sprintf("%d", opts.HealthCheckFail)
-			switch opts.HealthCheck {
+			switch opts.HealthCheckType {
 			case api.LB_HEALTH_CHECK_TCP:
 				params["HealthCheck.CheckType"] = "TCP"
 			case api.LB_HEALTH_CHECK_HTTP:
@@ -620,7 +620,7 @@ func healthCheck(params map[string]string, listenerType string, opts *cloudprovi
 			params["HealthCheck.IntervalTime"] = fmt.Sprintf("%d", opts.HealthCheckInterval)
 			params["HealthCheck.HealthNum"] = fmt.Sprintf("%d", opts.HealthCheckRise)
 			params["HealthCheck.UnHealthNum"] = fmt.Sprintf("%d", opts.HealthCheckFail)
-			switch opts.HealthCheck {
+			switch opts.HealthCheckType {
 			case api.LB_HEALTH_CHECK_PING:
 				params["HealthCheck.CheckType"] = "PING"
 				params["HealthCheck.CheckPort"] = "-1"


### PR DESCRIPTION
Cherry pick of #1089 on release/3.11.

#1089: fix(qcloud): lb listener health check type