### PR TITLE
Automated cherry pick of #1176: fix(esxi): skip not found host by storage

### DIFF
--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -189,6 +189,9 @@ func (self *SDatastore) getAttachedHosts() ([]cloudprovider.ICloudHost, error) {
 		idstr := moRefId(moStore.Host[i].Key)
 		host, err := self.datacenter.GetIHostByMoId(idstr)
 		if err != nil {
+			if errors.Cause(err) == cloudprovider.ErrNotFound {
+				continue
+			}
 			return nil, err
 		}
 		ihosts = append(ihosts, host)

--- a/pkg/multicloud/esxi/template.go
+++ b/pkg/multicloud/esxi/template.go
@@ -75,6 +75,7 @@ func (t *SVMTemplate) GetGlobalId() string {
 func (t *SVMTemplate) GetStatus() string {
 	ihosts, err := t.cache.datastore.GetAttachedHosts()
 	if err != nil {
+		log.Errorf("GetAttachedHosts for image %s error: %v", t.GetName(), err)
 		return api.CACHED_IMAGE_STATUS_CACHE_FAILED
 	}
 	for _, ihost := range ihosts {
@@ -88,6 +89,7 @@ func (t *SVMTemplate) GetStatus() string {
 			return api.CACHED_IMAGE_STATUS_CACHE_FAILED
 		}
 	}
+	log.Errorf("empty host attached for image %s", t.GetName())
 	return api.CACHED_IMAGE_STATUS_CACHE_FAILED
 }
 


### PR DESCRIPTION
Cherry pick of #1176 on release/3.11.10.

#1176: fix(esxi): skip not found host by storage