### PR TITLE
Automated cherry pick of #1200: Revert "fix(qcloud): waf instance id"

### DIFF
--- a/pkg/multicloud/qcloud/waf.go
+++ b/pkg/multicloud/qcloud/waf.go
@@ -79,7 +79,7 @@ func (self *SWafInstance) GetName() string {
 }
 
 func (self *SWafInstance) GetGlobalId() string {
-	return self.InstanceId
+	return self.Domain
 }
 
 func (self *SWafInstance) GetId() string {


### PR DESCRIPTION
Cherry pick of #1200 on release/3.11.10.

#1200: Revert "fix(qcloud): waf instance id"