### PR TITLE
Automated cherry pick of #1225: fix(esxi): ignore no default gateway host nic

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -444,6 +444,15 @@ func (host *SHost) fetchNicInfo(debug bool) []sHostNicInfo {
 	}
 
 	for _, nic := range vnics {
+		if nic.Spec.IpRouteSpec == nil {
+			continue
+		}
+		if nic.Spec.IpRouteSpec.IpRouteConfig.GetHostIpRouteConfig() == nil {
+			continue
+		}
+		if len(nic.Spec.IpRouteSpec.IpRouteConfig.GetHostIpRouteConfig().DefaultGateway) == 0 {
+			continue
+		}
 		// log.Debugf("vnic %d: %s %#v", i, jsonutils.Marshal(nic), nic)
 		mac := netutils.FormatMacAddr(nic.Spec.Mac)
 		pnic := findHostNicByMac(nicInfoList, mac)


### PR DESCRIPTION
Cherry pick of #1225 on release/3.11.

#1225: fix(esxi): ignore no default gateway host nic