### PR TITLE
Automated cherry pick of #1241: fix(aws): avoid Invalid device name /dev/sda error

### DIFF
--- a/pkg/multicloud/aws/image.go
+++ b/pkg/multicloud/aws/image.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/imagetools"
+	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/cloudmux/pkg/apis/compute"
 	"yunion.io/x/cloudmux/pkg/cloudprovider"
@@ -237,6 +238,9 @@ func (self *SImage) GetBlockDeviceNames() []string {
 	ret := []string{}
 	for _, dev := range self.BlockDeviceMapping {
 		ret = append(ret, dev.DeviceName)
+		if strings.HasPrefix(dev.DeviceName, "/dev/xvd") && !utils.IsInStringArray("/dev/sda", ret) { // 系统盘是/dev/xvda, 则不能指定devName 为 /dev/sda
+			ret = append(ret, "/dev/sda")
+		}
 	}
 	return ret
 }

--- a/pkg/multicloud/aws/instance.go
+++ b/pkg/multicloud/aws/instance.go
@@ -654,13 +654,7 @@ func (self *SInstance) AttachDisk(ctx context.Context, diskId string) error {
 		return errors.Wrap(err, "GetImage")
 	}
 
-	deviceNames := []string{}
-	// mix in image block device names
-	for i := range img.BlockDeviceMapping {
-		if !utils.IsInStringArray(img.BlockDeviceMapping[i].DeviceName, deviceNames) {
-			deviceNames = append(deviceNames, img.BlockDeviceMapping[i].DeviceName)
-		}
-	}
+	deviceNames := img.GetBlockDeviceNames()
 
 	name, err := NextDeviceName(deviceNames)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #1241 on release/3.11.

#1241: fix(aws): avoid Invalid device name /dev/sda error