### PR TITLE
Automated cherry pick of #1263: fix(qcloud): storage type hssd use system disk

### DIFF
--- a/pkg/multicloud/qcloud/storage.go
+++ b/pkg/multicloud/qcloud/storage.go
@@ -152,5 +152,5 @@ func (self *SStorage) GetMountPoint() string {
 }
 
 func (self *SStorage) IsSysDiskStore() bool {
-	return strings.ToLower(self.storageType) != api.STORAGE_CLOUD_HSSD
+	return true
 }


### PR DESCRIPTION
Cherry pick of #1263 on release/4.0.

#1263: fix(qcloud): storage type hssd use system disk