### PR TITLE
Automated cherry pick of #1286: fix(aws): lb backend id

### DIFF
--- a/pkg/multicloud/aws/loadbalancerbackend.go
+++ b/pkg/multicloud/aws/loadbalancerbackend.go
@@ -36,7 +36,7 @@ type SElbBackend struct {
 }
 
 type Target struct {
-	ID   string `json:"Id"`
+	Id   string `json:"Id"`
 	Port int    `json:"Port"`
 }
 
@@ -47,7 +47,7 @@ type TargetHealth struct {
 }
 
 func (self *SElbBackend) GetId() string {
-	return fmt.Sprintf("%s::%s::%d", self.group.GetId(), self.Target.ID, self.Target.Port)
+	return fmt.Sprintf("%s::%s::%d", self.group.GetId(), self.Target.Id, self.Target.Port)
 }
 
 func (self *SElbBackend) GetName() string {
@@ -91,7 +91,7 @@ func (self *SElbBackend) GetBackendRole() string {
 }
 
 func (self *SElbBackend) GetBackendId() string {
-	return self.Target.ID
+	return self.Target.Id
 }
 
 func (self *SElbBackend) SyncConf(ctx context.Context, port, weight int) error {

--- a/pkg/multicloud/aws/shell/backendgroup.go
+++ b/pkg/multicloud/aws/shell/backendgroup.go
@@ -24,7 +24,7 @@ func init() {
 	type LbbgIdOptions struct {
 		ID string
 	}
-	shellutils.R(&LbbgIdOptions{}, "elb-lbbg-show", "Show loadbalancer backendgroup", func(cli *aws.SRegion, args *LbbgIdOptions) error {
+	shellutils.R(&LbbgIdOptions{}, "lb-lbbg-show", "Show loadbalancer backendgroup", func(cli *aws.SRegion, args *LbbgIdOptions) error {
 		ret, err := cli.GetElbBackendgroup(args.ID)
 		if err != nil {
 			return err
@@ -33,8 +33,17 @@ func init() {
 		return nil
 	})
 
-	shellutils.R(&LbbgIdOptions{}, "elb-lbbg-delete", "Delete loadbalancer", func(cli *aws.SRegion, args *LbbgIdOptions) error {
+	shellutils.R(&LbbgIdOptions{}, "lb-lbbg-delete", "Delete loadbalancer", func(cli *aws.SRegion, args *LbbgIdOptions) error {
 		return cli.DeleteElbBackendGroup(args.ID)
+	})
+
+	shellutils.R(&LbbgIdOptions{}, "lb-lbbg-backend-list", "Delete loadbalancer", func(cli *aws.SRegion, args *LbbgIdOptions) error {
+		backends, err := cli.GetELbBackends(args.ID)
+		if err != nil {
+			return err
+		}
+		printList(backends, 0, 0, 0, nil)
+		return nil
 	})
 
 }

--- a/pkg/multicloud/aws/shell/lb.go
+++ b/pkg/multicloud/aws/shell/lb.go
@@ -37,6 +37,15 @@ func init() {
 		return nil
 	})
 
+	shellutils.R(&LbListOptions{}, "lb-lis-list", "List loadbalancer", func(cli *aws.SRegion, args *LbListOptions) error {
+		ret, _, e := cli.GetElbListeners(args.Id, "", args.Marker)
+		if e != nil {
+			return e
+		}
+		printList(ret, 0, 0, 0, []string{})
+		return nil
+	})
+
 	type LbIdOptions struct {
 		ID string
 	}


### PR DESCRIPTION
Cherry pick of #1286 on release/3.11.

#1286: fix(aws): lb backend id