### PR TITLE
Automated cherry pick of #1384: fix: add zone id for ssl create

### DIFF
--- a/pkg/cloudprovider/ssl.go
+++ b/pkg/cloudprovider/ssl.go
@@ -20,6 +20,7 @@ const (
 )
 
 type SSLCertificateCreateOptions struct {
+	DnsZoneId   string
 	Certificate string
 	PrivateKey  string
 }


### PR DESCRIPTION
Cherry pick of #1384 on release/4.0.

#1384: fix: add zone id for ssl create