### PR TITLE
Automated cherry pick of #1387: fix(gcp): eip associate type

### DIFF
--- a/pkg/multicloud/google/eip.go
+++ b/pkg/multicloud/google/eip.go
@@ -129,7 +129,7 @@ func (addr *SAddress) GetAssociationType() string {
 		return api.EIP_ASSOCIATE_TYPE_SERVER
 	}
 	for _, user := range addr.Users {
-		if strings.HasPrefix(user, "/instances/") {
+		if strings.Contains(user, "/instances/") {
 			return api.EIP_ASSOCIATE_TYPE_SERVER
 		}
 		if strings.Contains(user, "/forwardingRules/") {


### PR DESCRIPTION
Cherry pick of #1387 on release/4.0.0.

#1387: fix(gcp): eip associate type