### PR TITLE
Automated cherry pick of #1443: fix: add opts for cdn custom hostname

### DIFF
--- a/pkg/cloudprovider/cdn.go
+++ b/pkg/cloudprovider/cdn.go
@@ -293,6 +293,7 @@ type CacheConfig struct {
 type CustomHostname struct {
 	Id                    string
 	Hostname              string
+	CustomOriginServer    string
 	OwnershipVerification struct {
 		Name  string
 		Type  string
@@ -327,10 +328,14 @@ type CustomHostname struct {
 }
 
 type CustomHostnameCreateOptions struct {
-	Hostname string
-	SSL      struct {
+	CustomOriginServer string
+	Hostname           string
+	SSL                struct {
 		CertificateAuthority string
 		Method               string
+		BundleMethod         string
+		CustomCertificate    string
+		CustomKey            string
 		Settings             struct {
 			MinTLSVersion string `json:"min_tls_version"`
 		}


### PR DESCRIPTION
Cherry pick of #1443 on release/4.0.

#1443: fix: add opts for cdn custom hostname