### PR TITLE
Automated cherry pick of #1462: fix(region): sync aws lb backend ip

### DIFF
--- a/pkg/multicloud/aws/loadbalancerbackend.go
+++ b/pkg/multicloud/aws/loadbalancerbackend.go
@@ -21,6 +21,7 @@ import (
 	api "yunion.io/x/cloudmux/pkg/apis/compute"
 	"yunion.io/x/cloudmux/pkg/cloudprovider"
 	"yunion.io/x/cloudmux/pkg/multicloud"
+	"yunion.io/x/pkg/util/netutils"
 )
 
 type SElbBackends struct {
@@ -100,7 +101,11 @@ func (self *SElbBackend) Update(ctx context.Context, opts *cloudprovider.SLoadba
 }
 
 func (self *SElbBackend) GetIpAddress() string {
-	return ""
+	_, err := netutils.NewIPV4Addr(self.Target.Id)
+	if err != nil {
+		return ""
+	}
+	return self.Target.Id
 }
 
 func (self *SRegion) SyncElbBackend(backendId, serverId string, oldPort, newPort int) error {


### PR DESCRIPTION
Cherry pick of #1462 on release/4.0.

#1462: fix(region): sync aws lb backend ip