### PR TITLE
Automated cherry pick of #1538: fix(qcloud): sync sqlserver expired time

### DIFF
--- a/pkg/multicloud/qcloud/rds_sqlserver.go
+++ b/pkg/multicloud/qcloud/rds_sqlserver.go
@@ -112,7 +112,7 @@ type SSQLServer struct {
 	CrossBackupSaveDays int
 	CrossRegions        []string
 	DnsPodDomain        string
-	EndTime             string
+	EndTime             time.Time
 	HAFlag              string
 	InstanceId          string
 	InstanceNote        string
@@ -343,7 +343,7 @@ func (mssql *SSQLServer) IsAutoRenew() bool {
 }
 
 func (mssql *SSQLServer) GetExpiredAt() time.Time {
-	return time.Time{}
+	return mssql.EndTime
 }
 
 func (mssql *SSQLServer) GetVcpuCount() int {


### PR DESCRIPTION
Cherry pick of #1538 on release/4.0.

#1538: fix(qcloud): sync sqlserver expired time