### PR TITLE
Automated cherry pick of #1570: fix(qcloud): event lookup readonly

### DIFF
--- a/pkg/multicloud/qcloud/qcloud.go
+++ b/pkg/multicloud/qcloud/qcloud.go
@@ -511,7 +511,7 @@ func (client *SQcloudClient) getSdkClient(regionId string) (*common.Client, erro
 			return nil
 		}
 		if client.cpcfg.ReadOnly {
-			for _, prefix := range []string{"Get", "List", "Describe"} {
+			for _, prefix := range []string{"Get", "List", "Describe", "LookUpEvents"} {
 				if strings.HasPrefix(action, prefix) {
 					return respCheck, nil
 				}


### PR DESCRIPTION
Cherry pick of #1570 on release/4.0.

#1570: fix(qcloud): event lookup readonly