### PR TITLE
Automated cherry pick of #1780: fix(aws): avold only sync aws latest custom image

### DIFF
--- a/pkg/multicloud/aws/storagecache.go
+++ b/pkg/multicloud/aws/storagecache.go
@@ -62,7 +62,7 @@ func (self *SStoragecache) IsEmulated() bool {
 }
 
 func (self *SStoragecache) GetICustomizedCloudImages() ([]cloudprovider.ICloudImage, error) {
-	images, err := self.region.GetImages("", ImageOwnerSelf, nil, "", "hvm", nil, "", true)
+	images, err := self.region.GetImages("", ImageOwnerSelf, nil, "", "hvm", nil, "", false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "GetImages")
 	}


### PR DESCRIPTION
Cherry pick of #1780 on release/3.11.

#1780: fix(aws): avold only sync aws latest custom image