### PR TITLE
Automated cherry pick of #1799: fix(aws): avoid read only error

### DIFF
--- a/pkg/multicloud/aws/aws.go
+++ b/pkg/multicloud/aws/aws.go
@@ -217,7 +217,7 @@ func (client *SAwsClient) getHttpClient() (*http.Client, error) {
 
 		if client.cpcfg.ReadOnly {
 			if len(action) > 0 {
-				for _, prefix := range []string{"Get", "List", "Describe"} {
+				for _, prefix := range []string{"Get", "List", "Describe", "AssumeRole"} {
 					if strings.HasPrefix(action, prefix) {
 						return respCheck, nil
 					}


### PR DESCRIPTION
Cherry pick of #1799 on release/4.0.3.

#1799: fix(aws): avoid read only error